### PR TITLE
Fix for problem with email's queue

### DIFF
--- a/branches/DNN_5/Components/Email/Queue/IEmailQueueableSendTask.vb
+++ b/branches/DNN_5/Components/Email/Queue/IEmailQueueableSendTask.vb
@@ -1,5 +1,5 @@
 '
-' DotNetNuke® - http://www.dotnetnuke.com
+' DotNetNukeÂ® - http://www.dotnetnuke.com
 ' Copyright (c) 2002-2011
 ' by DotNetNuke Corporation
 '
@@ -198,7 +198,7 @@ Namespace DotNetNuke.Modules.Forum
             End If
 
             If Convert.ToString(HostController.Instance.GetSettingsDictionary("SMTPPassword")) <> String.Empty Then
-                SMTPPassword = Convert.ToString(HostController.Instance.GetSettingsDictionary("SMTPPassword"))
+				SMTPPassword = HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey())
             End If
 
             If Convert.ToString(HostController.Instance.GetSettingsDictionary("SMTPEnableSSL")) <> String.Empty Then


### PR DESCRIPTION
In current version it calls:
  HostController.Instance.GetSettingsDictionary("SMTPPassword")
what is wrong, because returns Encrypted version of the SMTPPassword. Instead it should use:
  HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey())